### PR TITLE
Add GitHub Actions Maven build workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,31 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 8
+      uses: actions/setup-java@v4
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: ./mvnw -B package --file pom.xml


### PR DESCRIPTION
- added standard "Java with Maven" workflow using GitHub UI
- changed JDK version to 8
- removed optional dependency graph upload, for simplicity

The build output is nice and clean, apart from the warning that the `GettingItWorking` submodule does not include production code, so the JAR created by the `package` phase is empty.

Possible improvements:
- Additionally build on latest LTS Java (currently 21) to test the experience of workshop attendees building on modern Java (using the "matrix" functionality - https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix)